### PR TITLE
Remove 'pyrolite' from setup.py dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
             'python-ternary',
             'scikit-image',
             'openpyxl',
-            'pyrolite',
             ],
 
     classifiers=[


### PR DESCRIPTION
Removed pyrolite from the list of dependencies in setup.py, consistent with commit 6872057 which removed it from environment.yml and docs/rtd_environment.yml. When doing an editable mode pip install, pyrolite's presence in setup.py triggered a warning about a missing dependency. Additionally, pyrolite pulled in mpltern which downgraded matplotlib from 3.10.8 to 3.8.4.